### PR TITLE
feature/2022-03-03

### DIFF
--- a/enumClass/enumClass.vcxproj
+++ b/enumClass/enumClass.vcxproj
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{e3deffbf-2911-4d23-a85f-da258fc2fa8b}</ProjectGuid>
+    <RootNamespace>enumClass</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/enumClass/enumClass.vcxproj.filters
+++ b/enumClass/enumClass.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="소스 파일">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="헤더 파일">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="리소스 파일">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/enumClass/main.cpp
+++ b/enumClass/main.cpp
@@ -1,7 +1,6 @@
 // C++ 11 에서 추가된 enum class 기존 enum에 네임스페이스를 정의해주기 위해 사용.
 // C 의 enum 차이점 주시
 #include <iostream>
-
 // C 계열 열거형은 enum 안에 들어간 네임을 변수로서 정의함. 즉 동일한 네이밍이 중복 발생하면 재정의됨.
 //enum EMnoitor
 //{
@@ -23,9 +22,9 @@
 // --> LG, SAMSUNG 등 동일한 네이밍으로 인한 재정의 발생. 컴파일러가 보통 막지만, 안막아 주는 곳도 있음.
 
 // enum 에 EMnoitor라는 네임스페이스를 추가해준다.
-enum class EMonitor
+enum class EMonitor:std::uint8_t
 {
-	LG = 0,
+	LG =0,
 	SAMSUNG,
 	ALPHASCAN,
 	PHILIPS,
@@ -34,18 +33,43 @@ enum class EMonitor
 };
 
 // enum 에 EKoreaMonitor 라는 네임스페이스를 추가해준다.
-enum class EKoreaMonitor
+enum class EKoreaMonitor:std::uint8_t
 {
-	LG,
+	LG=1,
 	SAMSUNG,
 	ALPHASCAN,
 	HANSUNG
 };
 
+
 int main(void)
 {
 	EMonitor monitor = EMonitor::LG;
 	EKoreaMonitor koreaMonitor = EKoreaMonitor::LG;
-
+	std::cout << "===================== 클래스 열거형 ======================" << std::endl;
 	std::cout << int(monitor) << int(koreaMonitor) << std::endl; // 무조건 명시적 캐스팅 수행
+
+
+	std::cout << "===================== 명시적 형변환 ======================" << std::endl;
+	// C++ 계열의 명시적 형변환 기본형에 대한 형변환은 C 와 차이가 없음
+	constexpr int num = 10;
+	std::cout << (char)num << " " << (double)num << " " << (short)num << " " << (float)num << std::endl;
+	std::cout << static_cast<char>(num) << " " << static_cast<double>(num) << " " << static_cast<short>(num) << " " << static_cast<float>(num) << std::endl;
+	// "포인터" 형변환을 좀 더 안정적으로 수행하도록 함
+
+
+	std::cout << "===================== 명시적 형변환 (static_cast) ======================" << std::endl;
+	const char* str = "MONITOR"; // const 컴파일러에러발생... constexpr 도 안됨 보통 이렇게 하는지 궁금
+	std::cout << (int)str << std::endl; // 포인터 변수 널 int 형으로 형변환 하겠다!! 
+	//static_cast<int>(str); 상수 char 포인터 변수를 int로 형변환 못함.
+
+	std::cout << "===================== 명시적 형변환 (const_cast) ======================" << std::endl;
+	// 상수에서 일반 변수로 변경하기 위해서는 const_cast를 사용해야 한다.
+	const char* productStr = "MONITOR";
+	//str = "BCD"; 에러
+	char* productName = const_cast<char*>(str); // 상수화 해제
+	std::cout << productName << std::endl;
+	char* color = const_cast<char*>("Red"); // 원래 Red는 상수기 때문에 const char* 타입에 값으로 사용 가능
+	std::cout << color << std::endl;
+	return 0;
 }

--- a/enumClass/main.cpp
+++ b/enumClass/main.cpp
@@ -1,0 +1,51 @@
+// C++ 11 에서 추가된 enum class 기존 enum에 네임스페이스를 정의해주기 위해 사용.
+// C 의 enum 차이점 주시
+#include <iostream>
+
+// C 계열 열거형은 enum 안에 들어간 네임을 변수로서 정의함. 즉 동일한 네이밍이 중복 발생하면 재정의됨.
+//enum EMnoitor
+//{
+//	LG=0,
+//	SAMSUNG,
+//	ALPHASCAN,
+//	PHILIPS,
+//	HANSUNG,
+//	ASUS
+//};
+//
+//enum EKoreaMonitor
+//{
+//	LG=1,
+//	SAMSUNG,
+//	ALPHASCAN,
+//	HANSUNG
+//};
+// --> LG, SAMSUNG 등 동일한 네이밍으로 인한 재정의 발생. 컴파일러가 보통 막지만, 안막아 주는 곳도 있음.
+
+// enum 에 EMnoitor라는 네임스페이스를 추가해준다.
+enum class EMonitor
+{
+	LG = 0,
+	SAMSUNG,
+	ALPHASCAN,
+	PHILIPS,
+	HANSUNG,
+	ASUS,
+};
+
+// enum 에 EKoreaMonitor 라는 네임스페이스를 추가해준다.
+enum class EKoreaMonitor
+{
+	LG,
+	SAMSUNG,
+	ALPHASCAN,
+	HANSUNG
+};
+
+int main(void)
+{
+	EMonitor monitor = EMonitor::LG;
+	EKoreaMonitor koreaMonitor = EKoreaMonitor::LG;
+
+	std::cout << int(monitor) << int(koreaMonitor) << std::endl; // 무조건 명시적 캐스팅 수행
+}

--- a/study-cpp.sln
+++ b/study-cpp.sln
@@ -7,6 +7,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "study-cpp", "study-cpp\stud
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "template", "template\template.vcxproj", "{FEA00A51-0783-490C-B32E-BCC96EFE8763}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "enumClass", "enumClass\enumClass.vcxproj", "{E3DEFFBF-2911-4D23-A85F-DA258FC2FA8B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -31,6 +33,14 @@ Global
 		{FEA00A51-0783-490C-B32E-BCC96EFE8763}.Release|x64.Build.0 = Release|x64
 		{FEA00A51-0783-490C-B32E-BCC96EFE8763}.Release|x86.ActiveCfg = Release|Win32
 		{FEA00A51-0783-490C-B32E-BCC96EFE8763}.Release|x86.Build.0 = Release|Win32
+		{E3DEFFBF-2911-4D23-A85F-DA258FC2FA8B}.Debug|x64.ActiveCfg = Debug|x64
+		{E3DEFFBF-2911-4D23-A85F-DA258FC2FA8B}.Debug|x64.Build.0 = Debug|x64
+		{E3DEFFBF-2911-4D23-A85F-DA258FC2FA8B}.Debug|x86.ActiveCfg = Debug|Win32
+		{E3DEFFBF-2911-4D23-A85F-DA258FC2FA8B}.Debug|x86.Build.0 = Debug|Win32
+		{E3DEFFBF-2911-4D23-A85F-DA258FC2FA8B}.Release|x64.ActiveCfg = Release|x64
+		{E3DEFFBF-2911-4D23-A85F-DA258FC2FA8B}.Release|x64.Build.0 = Release|x64
+		{E3DEFFBF-2911-4D23-A85F-DA258FC2FA8B}.Release|x86.ActiveCfg = Release|Win32
+		{E3DEFFBF-2911-4D23-A85F-DA258FC2FA8B}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
# enum class
- 학습 완료

# C++ Explicit Type Conversion
이해가 제대로 된 건지 모르겠습니다.
### static_cast<type>(obj)
- static한 type 들(literal, const)에 대해서, type Conversion작업을 수행해줌
- 포인터가 아닌 자료형의 type Conversion에 대해서는 기본 동작과 동일함.
- 포인터 자료형의 type Conversion 은 논리에 맞아야 가능함
   - ex 부모 포인터 ->형제 포인터 ok 
   - ex char* -> int* no

### const_cast<type>(obj)
- const 제약이 걸린 타입 ( const 변수, literal 값 ) 들을 일반 변수에 넣을 수 있게 Conversion해주는 역할